### PR TITLE
PT178: Move skip_slaves to get_slaves function

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -5090,13 +5090,8 @@ sub wait {
       my $watched = 0;
       @lagged_slaves = grep {
          my $slave_name = $_->{cxn}->name();
-<<<<<<< HEAD
          grep {$slave_name eq $_->name()} @{$slaves // []}
                             } @lagged_slaves;
-=======
-         grep {$slave_name eq $_->name()} @{$slaves || []}
-                             } @lagged_slaves;
->>>>>>> Revert "Revert "Merge pull request #119 from dveeden/reread_slaves_dsn""
 
       for my $i ( 0..$#lagged_slaves ) {
          my $lag;

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -5090,8 +5090,13 @@ sub wait {
       my $watched = 0;
       @lagged_slaves = grep {
          my $slave_name = $_->{cxn}->name();
+<<<<<<< HEAD
          grep {$slave_name eq $_->name()} @{$slaves // []}
                             } @lagged_slaves;
+=======
+         grep {$slave_name eq $_->name()} @{$slaves || []}
+                             } @lagged_slaves;
+>>>>>>> Revert "Revert "Merge pull request #119 from dveeden/reread_slaves_dsn""
 
       for my $i ( 0..$#lagged_slaves ) {
          my $lag;
@@ -8807,6 +8812,7 @@ sub main {
          channel      => $o->get('channel'),
       );
 
+<<<<<<< HEAD
       my $skip_slaves = $o->get('skip-check-slave-lag');
 
       my $get_slaves_cb = sub {
@@ -8826,6 +8832,20 @@ sub main {
             )
          );
       };
+=======
+      my $get_slaves_cb = sub {
+         my ($intolerant) = @_;
+         return( $ms->get_slaves(
+            dbh          => $cxn->dbh(),
+            dsn          => $cxn->dsn(),
+            make_cxn     => sub {
+               return $make_cxn->(@_, prev_dsn => $cxn->dsn(),
+                 errok => (not $intolerant));
+                                },
+                                )
+               );
+                              };
+>>>>>>> Revert "Revert "Merge pull request #119 from dveeden/reread_slaves_dsn""
 
       ### first ever call only: do not tolerate connection errors
       $slaves = $get_slaves_cb->('intolerant');

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -130,13 +130,13 @@ sub cmp {
    $v1 =~ s/[^\d\.]//;
    $v2 =~ s/[^\d\.]//;
 
-   my @a = ( $v1 =~ /(\d+)\.?/g );
-   my @b = ( $v2 =~ /(\d+)\.?/g );
+   my @a = ( $v1 =~ /(\d+)\.?/g ); 
+   my @b = ( $v2 =~ /(\d+)\.?/g ); 
    foreach my $n1 (@a) {
       $n1 += 0; #convert to number
       if (!@b) {
          return 1;
-      }
+      }  
       my $n2 = shift @b;
       $n2 += 0; # convert to number
       if ($n1 == $n2) {
@@ -144,8 +144,8 @@ sub cmp {
       }
       else {
          return $n1 <=> $n2;
-      }
-   }
+      }  
+   }  
    return @b ? -1 : 0;
 }
 
@@ -220,7 +220,7 @@ sub new {
       rules             => [],  # desc of rules for --help
       mutex             => [],  # rule: opts are mutually exclusive
       atleast1          => [],  # rule: at least one opt is required
-      disables          => {},  # rule: opt disables other opts
+      disables          => {},  # rule: opt disables other opts 
       defaults_to       => {},  # rule: opt defaults to value of other opt
       DSNParser         => undef,
       default_files     => [
@@ -383,7 +383,7 @@ sub _pod_to_specs {
          }
 
          push @specs, {
-            spec  => $self->{parse_attributes}->($self, $option, \%attribs),
+            spec  => $self->{parse_attributes}->($self, $option, \%attribs), 
             desc  => $para
                . (defined $attribs{default} ? " (default $attribs{default})" : ''),
             group => ($attribs{'group'} ? $attribs{'group'} : 'default'),
@@ -474,7 +474,7 @@ sub _parse_specs {
          $self->{opts}->{$long} = $opt;
       }
       else { # It's an option rule, not a spec.
-         PTDEBUG && _d('Parsing rule:', $opt);
+         PTDEBUG && _d('Parsing rule:', $opt); 
          push @{$self->{rules}}, $opt;
          my @participants = $self->_get_participants($opt);
          my $rule_ok = 0;
@@ -519,7 +519,7 @@ sub _parse_specs {
       PTDEBUG && _d('Option', $long, 'disables', @participants);
    }
 
-   return;
+   return; 
 }
 
 sub _get_participants {
@@ -606,7 +606,7 @@ sub _set_option {
 }
 
 sub get_opts {
-   my ( $self ) = @_;
+   my ( $self ) = @_; 
 
    foreach my $long ( keys %{$self->{opts}} ) {
       $self->{opts}->{$long}->{got} = 0;
@@ -737,7 +737,7 @@ sub _check_opts {
                   else {
                      $err = join(', ',
                                map { "--$self->{opts}->{$_}->{long}" }
-                               grep { $_ }
+                               grep { $_ } 
                                @restricted_opts[0..scalar(@restricted_opts) - 2]
                             )
                           . ' or --'.$self->{opts}->{$restricted_opts[-1]}->{long};
@@ -747,7 +747,7 @@ sub _check_opts {
             }
 
          }
-         elsif ( $opt->{is_required} ) {
+         elsif ( $opt->{is_required} ) { 
             $self->save_error("Required option --$long must be specified");
          }
 
@@ -1131,7 +1131,7 @@ sub clone {
       $clone{$scalar} = $self->{$scalar};
    }
 
-   return bless \%clone;
+   return bless \%clone;     
 }
 
 sub _parse_size {
@@ -1646,7 +1646,7 @@ sub extends {
 
 sub _load_module {
    my ($class) = @_;
-
+   
    (my $file = $class) =~ s{::|'}{/}g;
    $file .= '.pm';
    { local $@; eval { require "$file" } } # or warn $@;
@@ -1677,7 +1677,7 @@ sub has {
    my $caller = scalar caller();
 
    my $class_metadata = Lmo::Meta->metadata_for($caller);
-
+   
    for my $attribute ( ref $names ? @$names : $names ) {
       my %args   = @_;
       my $method = ($args{is} || '') eq 'ro'
@@ -1696,16 +1696,16 @@ sub has {
 
       if ( my $type_check = $args{isa} ) {
          my $check_name = $type_check;
-
+         
          if ( my ($aggregate_type, $inner_type) = $type_check =~ /\A(ArrayRef|Maybe)\[(.*)\]\z/ ) {
             $type_check = Lmo::Types::_nested_constraints($attribute, $aggregate_type, $inner_type);
          }
-
+         
          my $check_sub = sub {
             my ($new_val) = @_;
             Lmo::Types::check_type_constaints($attribute, $type_check, $check_name, $new_val);
          };
-
+         
          $class_metadata->{$attribute}{isa} = [$check_name, $check_sub];
          my $orig_method = $method;
          $method = sub {
@@ -2618,7 +2618,7 @@ sub run {
          $parent_exit->($child_pid) if $parent_exit;
          exit 0;
       }
-
+ 
       POSIX::setsid() or die "Cannot start a new session: $OS_ERROR";
       chdir '/'       or die "Cannot chdir to /: $OS_ERROR";
 
@@ -2644,7 +2644,7 @@ sub run {
 
          close STDERR;
          open  STDERR, ">&STDOUT"
-            or die "Cannot dupe STDERR to STDOUT: $OS_ERROR";
+            or die "Cannot dupe STDERR to STDOUT: $OS_ERROR"; 
       }
       else {
          if ( -t STDOUT ) {
@@ -2682,7 +2682,7 @@ sub _make_pid_file {
    eval {
       sysopen(PID_FH, $pid_file, O_RDWR|O_CREAT|O_EXCL) or die $OS_ERROR;
       print PID_FH $PID, "\n";
-      close PID_FH;
+      close PID_FH; 
    };
    if ( my $e = $EVAL_ERROR ) {
       if ( $e =~ m/file exists/i ) {
@@ -2869,7 +2869,7 @@ sub split_unquote {
       s/`\z//;
       s/``/`/g;
    }
-
+   
    return ($db, $tbl);
 }
 
@@ -3388,9 +3388,9 @@ sub parse {
 
 sub remove_quoted_text {
    my ($string) = @_;
-   $string =~ s/[^\\]`[^`]*[^\\]`//g;
-   $string =~ s/[^\\]"[^"]*[^\\]"//g;
-   $string =~ s/[^\\]'[^']*[^\\]'//g;
+   $string =~ s/[^\\]`[^`]*[^\\]`//g; 
+   $string =~ s/[^\\]"[^"]*[^\\]"//g; 
+   $string =~ s/[^\\]'[^']*[^\\]'//g; 
    return $string;
 }
 
@@ -4053,7 +4053,7 @@ sub get_id {
       my $sql  = q{SHOW STATUS LIKE 'wsrep\_local\_index'};
       my (undef, $wsrep_local_index) = $cxn->dbh->selectrow_array($sql);
       PTDEBUG && _d("Got cluster wsrep_local_index: ",$wsrep_local_index);
-      $unique_id = $wsrep_local_index."|";
+      $unique_id = $wsrep_local_index."|"; 
       foreach my $val ('server\_id', 'wsrep\_sst\_receive\_address', 'wsrep\_node\_name', 'wsrep\_node\_address') {
          my $sql = "SHOW VARIABLES LIKE '$val'";
          PTDEBUG && _d($cxn->name, $sql);
@@ -4083,7 +4083,7 @@ sub is_cluster_node {
       PTDEBUG && _d($sql); #don't invoke name() if it's not a Cxn!
    }
    else {
-      $dbh = $cxn->dbh();
+      $dbh = $cxn->dbh();      
       PTDEBUG && _d($cxn->name, $sql);
    }
 
@@ -4166,22 +4166,22 @@ use warnings FATAL => 'all';
 use English qw(-no_match_vars);
 use constant PTDEBUG => $ENV{PTDEBUG} || 0;
 
-sub check_recursion_method {
+sub check_recursion_method {                                                       
    my ($methods) = @_;
-   if ( @$methods != 1 ) {
-      if ( grep({ !m/processlist|hosts/i } @$methods)
-            && $methods->[0] !~ /^dsn=/i )
-      {
-         die  "Invalid combination of recursion methods: "
-            . join(", ", map { defined($_) ? $_ : 'undef' } @$methods) . ". "
-            . "Only hosts and processlist may be combined.\n"
-      }
-   }
-   else {
+   if ( @$methods != 1 ) {                                                         
+      if ( grep({ !m/processlist|hosts/i } @$methods)                              
+            && $methods->[0] !~ /^dsn=/i ) 
+      {     
+         die  "Invalid combination of recursion methods: "                         
+            . join(", ", map { defined($_) ? $_ : 'undef' } @$methods) . ". "      
+            . "Only hosts and processlist may be combined.\n"                      
+      }                                                                            
+   }     
+   else {   
       my ($method) = @$methods;
-      die "Invalid recursion method: " . ( $method || 'undef' )
-         unless $method && $method =~ m/^(?:processlist$|hosts$|none$|cluster$|dsn=)/i;
-   }
+      die "Invalid recursion method: " . ( $method || 'undef' )                    
+         unless $method && $method =~ m/^(?:processlist$|hosts$|none$|cluster$|dsn=)/i;     
+   }                                                                               
 }
 
 sub new {
@@ -4205,13 +4205,13 @@ sub get_slaves {
    }
    my ($make_cxn) = @args{@required_args};
 
-   my $slaves      = [];
-   my $dp          = $self->{DSNParser};
-   my $methods     = $self->_resolve_recursion_methods($args{dsn});
+   my $slaves  = [];
+   my $dp      = $self->{DSNParser};
+   my $methods = $self->_resolve_recursion_methods($args{dsn});
    my $skip_slaves = $args{skip_slaves};
 
    return $slaves unless @$methods;
-
+   
    if ( grep { m/processlist|hosts/i } @$methods ) {
       my @required_args = qw(dbh dsn);
       foreach my $arg ( @required_args ) {
@@ -4224,7 +4224,7 @@ sub get_slaves {
          {  dbh            => $dbh,
             dsn            => $dsn,
             slave_user     => $o->got('slave-user') ? $o->get('slave-user') : '',
-            slave_password => $o->got('slave-password') ? $o->get('slave-password') : '',
+            slave_password => $o->got('slave-password') ? $o->get('slave-password') : '', 
             callback  => sub {
                my ( $dsn, $dbh, $level, $parent ) = @_;
                return unless $level;
@@ -4274,7 +4274,7 @@ sub get_slaves {
       }
       $slaves = $filtered_slaves;
    }
-   
+
    return $slaves;
 }
 
@@ -4811,7 +4811,7 @@ sub short_host {
 }
 
 sub is_replication_thread {
-   my ( $self, $query, %args ) = @_;
+   my ( $self, $query, %args ) = @_; 
    return unless $query;
 
    my $type = lc($args{type} || 'all');
@@ -4826,7 +4826,7 @@ sub is_replication_thread {
    if ( !$match ) {
       if ( ($query->{User} || $query->{user} || '') eq "system user" ) {
          PTDEBUG && _d("Slave replication thread");
-         if ( $type ne 'all' ) {
+         if ( $type ne 'all' ) { 
             my $state = $query->{State} || $query->{state} || '';
 
             if ( $state =~ m/^init|end$/ ) {
@@ -4839,7 +4839,7 @@ sub is_replication_thread {
                    |Reading\sevent\sfrom\sthe\srelay\slog
                    |Has\sread\sall\srelay\slog;\swaiting
                    |Making\stemp\sfile
-                   |Waiting\sfor\sslave\smutex\son\sexit)/xi;
+                   |Waiting\sfor\sslave\smutex\son\sexit)/xi; 
 
                $match = $type eq 'slave_sql' &&  $slave_sql ? 1
                       : $type eq 'slave_io'  && !$slave_sql ? 1
@@ -4903,7 +4903,7 @@ sub get_replication_filters {
          replicate_do_db
          replicate_ignore_db
          replicate_do_table
-         replicate_ignore_table
+         replicate_ignore_table 
          replicate_wild_do_table
          replicate_wild_ignore_table
       );
@@ -4914,7 +4914,7 @@ sub get_replication_filters {
       $filters{slave_skip_errors} = $row->[1] if $row->[1] && $row->[1] ne 'OFF';
    }
 
-   return \%filters;
+   return \%filters; 
 }
 
 
@@ -5055,7 +5055,7 @@ sub wait {
    if ( $pr ) {
       $pr_callback = sub {
          my ($fraction, $elapsed, $remaining, $eta, $completed) = @_;
-         my $dsn_name = $worst->{cxn}->{dsn_name};
+         my $dsn_name = $worst->{cxn}->name();
          if ( defined $worst->{lag} ) {
             print STDERR "Replica lag is " . ($worst->{lag} || '?')
                . " seconds on $dsn_name.  Waiting.\n";
@@ -5064,25 +5064,25 @@ sub wait {
             if ($self->{fail_on_stopped_replication}) {
                 die 'replication is stopped';
             }
-            print STDERR "(1) Replica '$dsn_name' is stopped.  Waiting.\n";
+            print STDERR "Replica $dsn_name is stopped.  Waiting.\n";
          }
          return;
       };
       $pr->set_callback($pr_callback);
 
       $pr_first_report = sub {
-         my $dsn_name = $worst->{cxn}->{dsn_name};
+         my $dsn_name = $worst->{cxn}->name();
          if ( !defined $worst->{lag} ) {
             if ($self->{fail_on_stopped_replication}) {
                 die 'replication is stopped';
             }
-            print STDERR "(2) Replica $dsn_name is stopped.  Waiting.\n";
+            print STDERR "Replica $dsn_name is stopped.  Waiting.\n";
          }
          return;
       };
    }
 
-   my @lagged_slaves = map { {cxn=>$_, lag=>undef} } @$slaves;
+   my @lagged_slaves = map { {cxn=>$_, lag=>undef} } @$slaves;  
    while ( $oktorun->() && @lagged_slaves ) {
       PTDEBUG && _d('Checking slave lag');
 
@@ -5094,13 +5094,7 @@ sub wait {
                             } @lagged_slaves;
 
       for my $i ( 0..$#lagged_slaves ) {
-         my $lag;
-         eval {
-             $lag = $get_lag->($lagged_slaves[$i]->{cxn});
-         };
-         if ($EVAL_ERROR) {
-             die $EVAL_ERROR;
-         }
+         my $lag = $get_lag->($lagged_slaves[$i]->{cxn});
          PTDEBUG && _d($lagged_slaves[$i]->{cxn}->name(),
             'slave lag:', $lag);
          if ( !defined $lag || $lag > $max_lag ) {
@@ -5182,9 +5176,9 @@ sub new {
    my $self = {
       %args
    };
-
-   $self->{last_time} = time();
-
+   
+   $self->{last_time} = time();   
+   
    my (undef, $last_fc_ns) = $self->{node}->selectrow_array('SHOW STATUS LIKE "wsrep_flow_control_paused_ns"');
 
    $self->{last_fc_secs} = $last_fc_ns/1000_000_000;
@@ -5220,11 +5214,11 @@ sub wait {
       my $current_time = time();
       my (undef, $current_fc_ns) = $node->selectrow_array('SHOW STATUS LIKE "wsrep_flow_control_paused_ns"');
       my $current_fc_secs = $current_fc_ns/1000_000_000;
-      my $current_avg = ($current_fc_secs - $self->{last_fc_secs}) / ($current_time - $self->{last_time});
-      if ( $current_avg > $max_avg ) {
+      my $current_avg = ($current_fc_secs - $self->{last_fc_secs}) / ($current_time - $self->{last_time});  
+      if ( $current_avg > $max_avg ) { 
          if ( $pr ) {
             $pr->update(sub { return 0; });
-         }
+         } 
          PTDEBUG && _d('Calling sleep callback');
          if ( $self->{simple_progress} ) {
             print STDERR "Waiting for Flow Control to abate\n";
@@ -5339,7 +5333,7 @@ sub _parse_spec {
       }
    }
 
-   return \%max_val_for;
+   return \%max_val_for; 
 }
 
 sub max_values {
@@ -5392,7 +5386,7 @@ sub wait {
             die "$var=$val exceeds its critical threshold "
                . "$self->{critical_val_for}->{$var}\n";
          }
-         if ( $val >= $self->{max_val_for}->{$var} ) {
+         if ( $val && $val >= $self->{max_val_for}->{$var} ) {
             $vals_too_high{$var} = $val;
          }
          else {
@@ -5626,7 +5620,7 @@ sub new {
 
 sub switch_to_nibble {
     my $self = shift;
-    my $params = _nibble_params($self->{nibble_params}, $self->{tbl}, $self->{args}, $self->{cols},
+    my $params = _nibble_params($self->{nibble_params}, $self->{tbl}, $self->{args}, $self->{cols}, 
                                 $self->{chunk_size}, $self->{where}, $self->{comments}, $self->{Quoter});
 
     $self->{one_nibble}           = 0;
@@ -5663,7 +5657,7 @@ sub _one_nibble {
       my $explain_nibble_sql
          = "EXPLAIN SELECT "
          . ($args->{select} ? $args->{select}
-                          : join(', ', map{ $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum'
+                          : join(', ', map{ $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' 
                           ? "CAST(".$q->quote($_)." AS UNSIGNED)" : $q->quote($_) } @$cols))
          . " FROM $tbl->{name}"
          . ($where ? " WHERE $where" : '')
@@ -5760,7 +5754,7 @@ sub _nibble_params {
          . " /*$comments->{nibble}*/";
       PTDEBUG && _d('Nibble statement:', $nibble_sql);
 
-      my $explain_nibble_sql
+      my $explain_nibble_sql 
          = "EXPLAIN SELECT "
          . ($args->{select} ? $args->{select}
                           : join(', ', map { $q->quote($_) } @{$asc->{cols}}))
@@ -5849,7 +5843,7 @@ sub next {
             sleep($self->{sleep});
          }
       }
-
+  
       if ( !$self->{have_rows} ) {
          $self->{nibbleno}++;
          PTDEBUG && _d('Nibble:', $self->{nibble_sth}->{Statement}, 'params:',
@@ -5879,7 +5873,7 @@ sub next {
       }
       $self->{rowno}     = 0;
       $self->{have_rows} = 0;
-
+      
    }
 
    PTDEBUG && _d('Done nibbling');
@@ -6016,7 +6010,7 @@ sub can_nibble {
    }
 
    my $pause_file = ($o->has('pause-file') && $o->get('pause-file')) || undef;
-
+   
    return {
       row_est     => $row_est,      # nibble about this many rows
       index       => $index,        # using this index
@@ -6061,7 +6055,7 @@ sub _find_best_index {
          push @possible_indexes, $want_index;
       }
    }
-
+   
    if (!$best_index) {
       PTDEBUG && _d('Auto-selecting best index');
       foreach my $index ( $tp->sort_indexes($tbl_struct) ) {
@@ -6159,7 +6153,7 @@ sub _prepare_sths {
    return;
 }
 
-sub _get_bounds {
+sub _get_bounds { 
    my ($self) = @_;
 
    if ( $self->{one_nibble} ) {
@@ -6172,7 +6166,7 @@ sub _get_bounds {
    my $dbh = $self->{Cxn}->dbh();
 
    $self->{first_lower} = $dbh->selectrow_arrayref($self->{first_lb_sql});
-   PTDEBUG && _d('First lower boundary:', Dumper($self->{first_lower}));
+   PTDEBUG && _d('First lower boundary:', Dumper($self->{first_lower}));  
 
    if ( my $nibble = $self->{resume} ) {
       if (    defined $nibble->{lower_boundary}
@@ -6186,9 +6180,9 @@ sub _get_bounds {
       }
    }
    else {
-      $self->{next_lower}  = $self->{first_lower};
+      $self->{next_lower}  = $self->{first_lower};   
    }
-   PTDEBUG && _d('Next lower boundary:', Dumper($self->{next_lower}));
+   PTDEBUG && _d('Next lower boundary:', Dumper($self->{next_lower}));  
 
    if ( !$self->{next_lower} ) {
       PTDEBUG && _d('At end of table, or no more boundaries to resume');
@@ -6274,7 +6268,7 @@ sub _next_boundaries {
       $self->{upper} = $dbh->selectrow_arrayref($self->{last_ub_sql});
       PTDEBUG && _d('Last upper boundary:', Dumper($self->{upper}));
       $self->{no_more_boundaries} = 1;  # for next call
-
+      
       $self->{last_upper} = $self->{upper};
    }
    $self->{ub_sth}->finish();
@@ -6624,7 +6618,7 @@ sub value_to_json {
 
    my $b_obj = B::svref_2object(\$value);  # for round trip problem
    my $flags = $b_obj->FLAGS;
-   return $value # as is
+   return $value # as is 
       if $flags & ( B::SVp_IOK | B::SVp_NOK ) and !( $flags & B::SVp_POK ); # SvTYPE is IV or NV?
 
    my $type = ref($value);
@@ -7132,7 +7126,7 @@ sub _split_url {
                   or die(qq/SSL certificate not valid for $host\n/);
             }
        }
-
+         
        $self->{host} = $host;
        $self->{port} = $port;
 
@@ -7607,7 +7601,7 @@ my @vc_dirs = (
       }
       PTDEBUG && _d('Version check file', $file, 'in', $ENV{PWD});
       return $file;  # in the CWD
-   }
+   } 
 }
 
 sub version_check_time_limit {
@@ -7624,11 +7618,11 @@ sub version_check {
    PTDEBUG && _d('FindBin::Bin:', $FindBin::Bin);
    if ( !$args{force} ) {
       if ( $FindBin::Bin
-           && (-d "$FindBin::Bin/../.bzr"    ||
+           && (-d "$FindBin::Bin/../.bzr"    || 
                -d "$FindBin::Bin/../../.bzr" ||
-               -d "$FindBin::Bin/../.git"    ||
-               -d "$FindBin::Bin/../../.git"
-              )
+               -d "$FindBin::Bin/../.git"    || 
+               -d "$FindBin::Bin/../../.git" 
+              ) 
          ) {
          PTDEBUG && _d("$FindBin::Bin/../.bzr disables --version-check");
          return;
@@ -7652,7 +7646,7 @@ sub version_check {
       PTDEBUG && _d(scalar @$instances_to_check, 'instances to check');
       return unless @$instances_to_check;
 
-      my $protocol = 'https';
+      my $protocol = 'https';  
       eval { require IO::Socket::SSL; };
       if ( $EVAL_ERROR ) {
          PTDEBUG && _d($EVAL_ERROR);
@@ -7660,13 +7654,15 @@ sub version_check {
          return;
       }
       PTDEBUG && _d('Using', $protocol);
+      my $url = $args{url}                       # testing
+                || $ENV{PERCONA_VERSION_CHECK_URL}  # testing
+                || "$protocol://v.percona.com";
+      PTDEBUG && _d('API URL:', $url);
 
       my $advice = pingback(
          instances => $instances_to_check,
          protocol  => $protocol,
-         url       => $args{url}                       # testing
-                   || $ENV{PERCONA_VERSION_CHECK_URL}  # testing
-                   || "$protocol://v.percona.com",
+         url       => $url,
       );
       if ( $advice ) {
          PTDEBUG && _d('Advice:', Dumper($advice));
@@ -7824,12 +7820,17 @@ sub get_uuid {
     my $filename = $ENV{"HOME"} . $uuid_file;
     my $uuid = _generate_uuid();
 
-    open(my $fh, '>', $filename) or die "Could not open file '$filename' $!";
-    print $fh $uuid;
-    close $fh;
+    my $fh;
+    eval {
+        open($fh, '>', $filename);
+    };
+    if (!$EVAL_ERROR) {
+        print $fh $uuid;
+        close $fh;
+    }
 
     return $uuid;
-}
+}   
 
 sub _generate_uuid {
     return sprintf+($}="%04x")."$}-$}-$}-$}-".$}x3,map rand 65537,0..7;
@@ -7878,7 +7879,7 @@ sub pingback {
    );
    die "Failed to parse server requested programs: $response->{content}"
       if !scalar keys %$items;
-
+      
    my $versions = get_versions(
       items     => $items,
       instances => $instances,
@@ -7892,8 +7893,9 @@ sub pingback {
       general_id => get_uuid(),
    );
 
+   my $tool_name = $ENV{XTRABACKUP_VERSION} ? "Percona XtraBackup" : File::Basename::basename($0);
    my $client_response = {
-      headers => { "X-Percona-Toolkit-Tool" => File::Basename::basename($0) },
+      headers => { "X-Percona-Toolkit-Tool" => $tool_name },
       content => $client_content,
    };
    PTDEBUG && _d('Client response:', Dumper($client_response));
@@ -7976,6 +7978,7 @@ my %sub_for_type = (
    perl_version        => \&get_perl_version,
    perl_module_version => \&get_perl_module_version,
    mysql_variable      => \&get_mysql_variable,
+   xtrabackup          => \&get_xtrabackup_version,
 );
 
 sub valid_item {
@@ -8103,6 +8106,10 @@ sub get_perl_version {
    return $version;
 }
 
+sub get_xtrabackup_version {
+    return $ENV{XTRABACKUP_VERSION};
+}
+
 sub get_perl_module_version {
    my (%args) = @_;
    my $item = $args{item};
@@ -8137,7 +8144,7 @@ sub get_from_mysql {
    if ($item->{item} eq 'MySQL' && $item->{type} eq 'mysql_variable') {
       @{$item->{vars}} = grep { $_ eq 'version' || $_ eq 'version_comment' } @{$item->{vars}};
    }
-
+ 
 
    my @versions;
    my %version_for;
@@ -8242,7 +8249,7 @@ sub find_cluster_nodes {
    my $dp  = $args{DSNParser};
    my $make_cxn = $args{make_cxn};
 
-
+   
    my $sql = q{SHOW STATUS LIKE 'wsrep\_incoming\_addresses'};
    PTDEBUG && _d($sql);
    my (undef, $addresses) = $dbh->selectrow_array($sql);
@@ -8322,7 +8329,7 @@ sub autodetect_nodes {
    my $new_nodes = [];
 
    return $new_nodes unless @$nodes;
-
+   
    for my $node ( @$nodes ) {
       my $nodes_found = $self->find_cluster_nodes(
          dbh       => $node->dbh(),
@@ -8354,12 +8361,12 @@ sub autodetect_nodes {
    );
 
    my @new_slave_nodes = grep { $self->is_cluster_node($_) } @$new_slaves;
-
+   
    my $slaves_of_slaves = $self->autodetect_nodes(
          %args,
          nodes => \@new_slave_nodes,
    );
-
+   
    my @autodetected_nodes = ( @$new_nodes, @$new_slaves, @$slaves_of_slaves );
    return \@autodetected_nodes;
 }
@@ -8807,12 +8814,11 @@ sub main {
          channel      => $o->get('channel'),
       );
 
-<<<<<<< HEAD
       my $skip_slaves = $o->get('skip-check-slave-lag');
 
       my $get_slaves_cb = sub {
          my ($intolerant) = @_;
-         return ( 
+         return (
             $ms->get_slaves(
                dbh          => $cxn->dbh(),
                dsn          => $cxn->dsn(),
@@ -8827,20 +8833,6 @@ sub main {
             )
          );
       };
-=======
-      my $get_slaves_cb = sub {
-         my ($intolerant) = @_;
-         return( $ms->get_slaves(
-            dbh          => $cxn->dbh(),
-            dsn          => $cxn->dsn(),
-            make_cxn     => sub {
-               return $make_cxn->(@_, prev_dsn => $cxn->dsn(),
-                 errok => (not $intolerant));
-                                },
-                                )
-               );
-                              };
->>>>>>> Revert "Revert "Merge pull request #119 from dveeden/reread_slaves_dsn""
 
       ### first ever call only: do not tolerate connection errors
       $slaves = $get_slaves_cb->('intolerant');
@@ -8875,24 +8867,6 @@ sub main {
       }
 
       if ( $slave_lag_cxns && scalar @$slave_lag_cxns ) {
-         if ($o->get('skip-check-slave-lag')) {
-             my $slaves_to_skip = $o->get('skip-check-slave-lag');
-             my $filtered_slaves = [];
-             for my $slave (@$slave_lag_cxns) {
-                 my $found=0;
-                 for my $slave_to_skip (@$slaves_to_skip) {
-                     if ($slave->{dsn}->{h} eq $slave_to_skip->{h} && $slave->{dsn}->{P} eq $slave_to_skip->{P}) {
-                         $found=1;
-                     }
-                 }
-                 if ($found) {
-                    print "Skipping slave ". $slave->description()."\n";
-                 } else {
-                    push @$filtered_slaves, $slave;
-                 }
-             }
-             $slave_lag_cxns = $filtered_slaves;
-         }
          if (!scalar @$slave_lag_cxns) {
             print "Not checking slave lag because all slaves were skipped\n";
          } else{

--- a/lib/MasterSlave.pm
+++ b/lib/MasterSlave.pm
@@ -71,6 +71,7 @@ sub get_slaves {
    my $slaves  = [];
    my $dp      = $self->{DSNParser};
    my $methods = $self->_resolve_recursion_methods($args{dsn});
+   my $skip_slaves = $args{skip_slaves};
 
    return $slaves unless @$methods;
    
@@ -118,7 +119,25 @@ sub get_slaves {
    else {
       die "Unexpected recursion methods: @$methods";
    }
-   
+
+   if ($skip_slaves) {
+      my $filtered_slaves = [];
+      for my $slave (@$slaves) {
+         my $found=0;
+         for my $slave_to_skip (@$skip_slaves) {
+            if ($slave->{dsn}->{h} eq $skip_slaves->{h} && $slave->{dsn}->{P} eq $skip_slaves->{P}) {
+                  $found=1;
+            }
+         }
+         if ($found) {
+            print "Skipping slave ". $slave->description()."\n";
+         } else {
+            push @$filtered_slaves, $slave;
+         }
+      }
+      $slaves = $filtered_slaves;
+   }
+
    return $slaves;
 }
 


### PR DESCRIPTION
**Notice** You may want to rebase your branch on percona-toolking master, to reduce the comparison

- Updated `mysql_random_data_load` to a working version, the version on the repo was not working with my tests
- Reduced `t/pt-online-schema-change/slave-lag.t` number of entries to insert to in `5000` to make it run faster
- Moved `skip_slaves` to the `get_slaves` function so it consistently skip slaves throughout the code.